### PR TITLE
fix: service account key takes id instead of account_id

### DIFF
--- a/modules/google_service_account/main.tf
+++ b/modules/google_service_account/main.tf
@@ -31,7 +31,9 @@ resource "google_service_account" "service_account" {
 resource "google_service_account_key" "keys" {
   for_each = toset(var.key_aliases)
 
-  service_account_id = google_service_account.service_account.account_id
+  # https://github.com/hashicorp/terraform-provider-google/issues/9617
+  # project is implicitly passed from google_service_account ID as projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}
+  service_account_id = google_service_account.service_account.id
 }
 
 resource "google_project_iam_member" "in_project_roles" {


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

Due to the existing error on `iac-iam-*` TFC, the service account for `user-iam` cannot create service account keys with error `project is not set`. 

In order to fix this, the `service_account_id` argument for `google_service_account_key` must contain the implicit `project_id` in format `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}` so that even without project from the provider,  `google_service_account_key` can still find the project from `service_account_id`.

To implement this, `service_account_id` takes `google_service_account.id` instead of `google_service_account.account_id`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-iam/10)
<!-- Reviewable:end -->
