### PR TITLE
feat: allow more than 1 cross project IAM binding per service account

### DIFF
--- a/examples/google_service_account_cross_project_test/inputs.tf
+++ b/examples/google_service_account_cross_project_test/inputs.tf
@@ -21,8 +21,4 @@ variable "cross_project_iam_role_memberships" {
   default     = {}
   description = "A map of GCP project IDs and an associated list of IAM roles to add a membership to."
   type        = map(list(string))
-  validation {
-    condition     = length(var.cross_project_iam_role_memberships) < 2
-    error_message = "To maintain a cleaner security model, only one project is currently supported for cross-project role memberships."
-  }
 }

--- a/modules/google_service_account/inputs.tf
+++ b/modules/google_service_account/inputs.tf
@@ -7,10 +7,6 @@ variable "cross_project_iam_role_memberships" {
   default     = {}
   description = "A map of GCP project IDs and an associated list of IAM roles to add a membership to."
   type        = map(list(string))
-  validation {
-    condition     = length(var.cross_project_iam_role_memberships) < 2
-    error_message = "To maintain a cleaner security model, only one project is currently supported for cross-project role memberships."
-  }
 }
 
 variable "description" {
@@ -27,10 +23,6 @@ variable "folder_iam_role_memberships" {
   default     = {}
   description = "A map of GCP folder IDs and an associated list of IAM roles to add a membership to."
   type        = map(list(string))
-  validation {
-    condition     = length(var.folder_iam_role_memberships) < 2
-    error_message = "To maintain a cleaner security model, only one folder is currently supported for folder role memberships."
-  }
 }
 
 variable "iam_role_membership_type" {

--- a/test/go.mod
+++ b/test/go.mod
@@ -3,7 +3,6 @@ module github.com/honestbank/terraform-gcp-iam/v2
 go 1.17
 
 require (
-	cloud.google.com/go/storage v1.22.1
 	github.com/gruntwork-io/terratest v0.40.6
 	github.com/stretchr/testify v1.7.0
 )
@@ -12,6 +11,7 @@ require (
 	cloud.google.com/go v0.102.0 // indirect
 	cloud.google.com/go/compute v1.6.1 // indirect
 	cloud.google.com/go/iam v0.3.0 // indirect
+	cloud.google.com/go/storage v1.22.1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.40.56 // indirect

--- a/test/google_service_account_cross_project_test.go
+++ b/test/google_service_account_cross_project_test.go
@@ -155,6 +155,6 @@ func TestGoogleServiceAccountCrossProjectMultipleProjects(t *testing.T) {
 
 	test_structure.RunTestStage(t, testCaseName+"_terraform_plan", func() {
 		_, planErr := terraform.PlanE(t, terraformOptions)
-		assert.NotNil(t, planErr, "plan should error when 2 external projects are specified")
+		assert.Nil(t, planErr, "plan should not error when 2 external projects are specified")
 	})
 }

--- a/test/google_service_account_cross_project_with_condition_test.go
+++ b/test/google_service_account_cross_project_with_condition_test.go
@@ -104,10 +104,11 @@ func TestGoogleServiceAccountCrossProjectMultipleProjectsWithCondition(t *testin
 	run := strings.ToLower(random.UniqueId())
 
 	// [roles/iam.serviceAccountAdmin, roles/iam.serviceAccountKeyAdmin] required in this project
-	gcpServiceAccountHostProject := "test-terraform-project-01"
+	gcpServiceAccountHostProject := os.Getenv("GOOGLE_PROJECT")
 
 	// [roles/iam.securityAdmin] required in this project
 	gcpCrossProjectIamRoleMembershipProjectId := "storage-0994"
+	gcpCrossProjectIamRoleMembershipProjectId2 := "tf-shared-vpc-host-78a3"
 	gcpIndonesiaRegion := "asia-southeast2"
 
 	// GCP credentials will be sourced from this var. Do not use `GOOGLE_CREDENTIALS`
@@ -149,8 +150,8 @@ func TestGoogleServiceAccountCrossProjectMultipleProjectsWithCondition(t *testin
 				"iam_role_membership_type": "CROSS_PROJECT",
 				// Two projects should cause an error
 				"cross_project_iam_role_memberships": map[string][]string{
-					gcpCrossProjectIamRoleMembershipProjectId: {"roles/storage.objectViewer"},
-					"some-other-project":                      {"roles/storage.objectViewer"},
+					gcpCrossProjectIamRoleMembershipProjectId:  {"roles/storage.objectViewer"},
+					gcpCrossProjectIamRoleMembershipProjectId2: {"roles/storage.objectViewer"},
 				},
 				"conditions": []map[string]string{
 					{
@@ -169,6 +170,6 @@ func TestGoogleServiceAccountCrossProjectMultipleProjectsWithCondition(t *testin
 
 	test_structure.RunTestStage(t, testCaseName+"_terraform_plan", func() {
 		_, planErr := terraform.PlanE(t, terraformOptions)
-		assert.NotNil(t, planErr, "plan should error when 2 external projects are specified")
+		assert.Nil(t, planErr, "plan should not error when 2 external projects are specified")
 	})
 }

--- a/test/google_service_account_folder_test.go
+++ b/test/google_service_account_folder_test.go
@@ -104,6 +104,7 @@ func TestGoogleServiceAccountCrossProjectMultipleFolders(t *testing.T) {
 	// [roles/iam.securityAdmin] required on this folder
 	// 502911218937 is the folder titled `terraform automated testing`
 	folderIamRoleMembershipFolderId := "502911218937"
+	folderIamRoleMembershipFolderId2 := "1004506453476"
 	gcpIndonesiaRegion := "asia-southeast2"
 
 	// GCP credentials will be sourced from this var. Do not use `GOOGLE_CREDENTIALS`
@@ -145,8 +146,8 @@ func TestGoogleServiceAccountCrossProjectMultipleFolders(t *testing.T) {
 				"iam_role_membership_type": "FOLDER",
 				// Two folders should cause an error
 				"folder_iam_role_memberships": map[string][]string{
-					folderIamRoleMembershipFolderId: {"roles/viewer"},
-					"1234567890":                    {"roles/viewer"},
+					folderIamRoleMembershipFolderId:  {"roles/viewer"},
+					folderIamRoleMembershipFolderId2: {"roles/viewer"},
 				},
 			},
 		})
@@ -158,6 +159,6 @@ func TestGoogleServiceAccountCrossProjectMultipleFolders(t *testing.T) {
 
 	test_structure.RunTestStage(t, testCaseName+"_terraform_plan", func() {
 		_, planErr := terraform.PlanE(t, terraformOptions)
-		assert.NotNil(t, planErr, "plan should error when 2 external projects are specified")
+		assert.Nil(t, planErr, "plan should not error when 2 external projects are specified")
 	})
 }

--- a/test/google_service_account_folder_with_condition_test.go
+++ b/test/google_service_account_folder_with_condition_test.go
@@ -111,6 +111,7 @@ func TestGoogleServiceAccountCrossProjectMultipleFoldersWithCondition(t *testing
 	// [roles/iam.securityAdmin] required on this folder
 	// 502911218937 is the folder titled `terraform automated testing`
 	folderIamRoleMembershipFolderId := "502911218937"
+	folderIamRoleMembershipFolderId2 := "1004506453476"
 	gcpIndonesiaRegion := "asia-southeast2"
 
 	// GCP credentials will be sourced from this var. Do not use `GOOGLE_CREDENTIALS`
@@ -152,8 +153,8 @@ func TestGoogleServiceAccountCrossProjectMultipleFoldersWithCondition(t *testing
 				"iam_role_membership_type": "FOLDER",
 				// Two folders should cause an error
 				"folder_iam_role_memberships": map[string][]string{
-					folderIamRoleMembershipFolderId: {"roles/storage.objectViewer"},
-					"1234567890":                    {"roles/storage.objectViewer"},
+					folderIamRoleMembershipFolderId:  {"roles/storage.objectViewer"},
+					folderIamRoleMembershipFolderId2: {"roles/storage.objectViewer"},
 				},
 				"conditions": []map[string]string{
 					{
@@ -173,6 +174,6 @@ func TestGoogleServiceAccountCrossProjectMultipleFoldersWithCondition(t *testing
 
 	test_structure.RunTestStage(t, testCaseName+"_terraform_plan", func() {
 		_, planErr := terraform.PlanE(t, terraformOptions)
-		assert.NotNil(t, planErr, "plan should error when 2 external projects are specified")
+		assert.Nil(t, planErr, "plan should not error when 2 external projects are specified")
 	})
 }

--- a/test/google_service_account_test.go
+++ b/test/google_service_account_test.go
@@ -20,6 +20,7 @@ func TestGoogleServiceAccountInProject(t *testing.T) {
 	// Can be any project and region, need to source from env var
 	gcpProject := os.Getenv("GOOGLE_PROJECT")
 	gcpIndonesiaRegion := "asia-southeast2"
+	logger.Log(t, gcpProject)
 
 	// GCP credentials will be sourced from this var. Do not use `GOOGLE_CREDENTIALS`
 	// since we will be using that for validating Terraform-created credentials.


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Remove constraint of only 1 cross project IAM membership binding for service accounts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-iam/11)
<!-- Reviewable:end -->
