### PR TITLE
fix: update the project iam membership to use count index instead of …

### DIFF
--- a/modules/google_service_account/iam-memberships.tf
+++ b/modules/google_service_account/iam-memberships.tf
@@ -21,18 +21,14 @@ locals {
 }
 
 resource "google_project_iam_member" "project_iam_memberships" {
-  for_each = {
-    for membership in var.project_iam_memberships :
-    membership.role => membership
-  }
-
+  count  = length(local.folder_iam_memberships)
   member = "serviceAccount:${google_service_account.service_account.email}"
 
   project = var.project_id
-  role    = each.value.role
+  role    = local.folder_iam_memberships[count.index].role
 
   dynamic "condition" {
-    for_each = each.value.conditions != null ? each.value.conditions : []
+    for_each = local.folder_iam_memberships[count.index].conditions != null ? local.folder_iam_memberships[count.index].conditions : []
     content {
       description = condition.value.description
       expression  = condition.value.expression


### PR DESCRIPTION
…foreach

<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* when trying to add roles that need dependencies, foreach will break since it cannot run each element because it cannot get from the remote state.
* in this PR change to count index instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-iam/16)
<!-- Reviewable:end -->
