### PR TITLE
ci(semantic-release): Fix token permissions

### DIFF
--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -1,5 +1,7 @@
 name: terratest
-permissions: read-all
+permissions:
+  pull-requests: write
+  contents: write
 
 on:
   pull_request:


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

Update GITHUB_TOKEN permissions in the terratest workflow to allow Semantic Release to function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-iam/27)
<!-- Reviewable:end -->
